### PR TITLE
[Refactor] 작품 목록, 상세 관련 QA

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -25,6 +25,7 @@ interface CSVRecord {
   title: string;
   content: string;
   workImg: string;
+  subject: string;
 }
 
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -71,6 +72,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
       title: first.title,
       content: first.content,
       workImg: first.workImg,
+      subject: first.subject,
       designer,
     };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Providers from '@/app/providers/Provider';
 import Header from '@/app/components/Header';
 import Footer from '@/app/components/Footer';
+import ClearLocalStorageOnNavigate from '@/lib/ClearLocalStorageOnNavigate';
 
 export const metadata: Metadata = {
   title: 'DUKSUNG VCD 2025 졸업전시 | The Rough Sektch on the Ground',
@@ -24,6 +25,7 @@ export default function RootLayout({
       </head>
       <body>
         <Providers>
+          <ClearLocalStorageOnNavigate />
           <Header />
           <main>{children}</main>
           <Footer />

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -17,6 +17,7 @@ interface ProjectDetail {
   title: string;
   content: string;
   workImg: string;
+  subject: string;
   designer: Designer;
 }
 
@@ -45,6 +46,10 @@ export default function ProjectDetailPage({ params }: PageProps) {
       if (!res.ok) throw new Error('Failed to fetch project data');
       const data: ProjectDetail = await res.json();
       setProject(data);
+      // subject를 localStorage에 저장
+      if (data.subject) {
+        localStorage.setItem('selectedSubject', data.subject);
+      }
     }
     fetchProject();
   }, [id]);

--- a/src/app/projects/components/cardBoxStyle.ts
+++ b/src/app/projects/components/cardBoxStyle.ts
@@ -6,8 +6,7 @@ export const Container = styled.div`
   flex-direction: column;
   gap: 26px;
 
-  width: calc(50% - 20px);
-  max-width: 380px;
+  width: calc(33% - 26px);
 
   cursor: pointer;
 

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -35,9 +35,28 @@ const SUBJECT_MAPPING: Record<string, string> = {
   'video-design': '영상콘텐츠디자인',
 };
 
+// 한글 subject를 영문 id로 변환
+const SUBJECT_KOR_TO_ENG: Record<string, string> = {
+  커뮤니케이션디자인: 'communication-design',
+  일러스트레이션: 'illustration-design',
+  영상콘텐츠디자인: 'video-design',
+};
+
 export default function ProjectsPage() {
   const router = useRouter();
-  const [selectedSubject, setSelectedSubject] = useState<string>('communication-design');
+  const [selectedSubject, setSelectedSubject] = useState<string>(() => {
+    // 클라이언트 환경에서만 localStorage 접근
+    if (typeof window !== 'undefined') {
+      const savedSubject = localStorage.getItem('selectedSubject');
+      if (savedSubject) {
+        // 적용 후 바로 삭제
+        localStorage.removeItem('selectedSubject');
+        // 한글로 저장된 subject를 영문 id로 변환
+        return SUBJECT_KOR_TO_ENG[savedSubject] || savedSubject;
+      }
+    }
+    return 'communication-design';
+  });
   const [subjectGroups, setSubjectGroups] = useState<SubjectGroup[]>([]);
 
   useEffect(() => {

--- a/src/app/projects/pageStyle.ts
+++ b/src/app/projects/pageStyle.ts
@@ -39,7 +39,7 @@ export const SubjectConatiner = styled.div`
 
 export const SubjectImage = styled.img<{ $pcSrc: string; $tabletSrc: string; $mobileSrc: string }>`
   position: absolute;
-  top: 3%;
+  top: 100px;
   right: 0;
   z-index: -1;
   transform: translateX(8%);
@@ -51,7 +51,7 @@ export const SubjectImage = styled.img<{ $pcSrc: string; $tabletSrc: string; $mo
   content: url(${(props) => props.$pcSrc});
 
   ${media.tablet} {
-    top: 2%;
+    top: 60px;
     transform: translateX(16%);
 
     width: 65vw;
@@ -59,7 +59,7 @@ export const SubjectImage = styled.img<{ $pcSrc: string; $tabletSrc: string; $mo
   }
 
   ${media.mobile} {
-    top: 2.5%;
+    top: 55px;
     transform: translateX(21%);
     opacity: 0.5;
 

--- a/src/lib/ClearLocalStorageOnNavigate.tsx
+++ b/src/lib/ClearLocalStorageOnNavigate.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+export default function ClearLocalStorageOnNavigate() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // projects 페이지가 아닌 경우에만 localStorage 삭제
+    if (pathname && !pathname.startsWith('/projects')) {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('selectedSubject');
+      }
+    }
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
### 📑 이슈 번호

- close #16 

### ✨️ 작업 내용

1. 작품 목록 top 이슈
2. 프로젝트 카드 너비
3. 작품 과목 정보 저장 및 뒤로가기 반영

### 💭 코멘트

1. **작품 과목 정보 저장 및 뒤로가기 반영**
> 해당 기능 구현을 위해 localStorage를 활용했으며, `src/lib/ClearLocalStorageOnNavigate.tsx`로 hook을 만들어 페이지 이동시 삭제하여 프로젝트 페이지에만 반영될 수 있도록 구현했습니다.

### 📸 구현 결과

`변경되는 UI가 없어 첨부하지 않습니다.`